### PR TITLE
Accept proxyName as optional configuration

### DIFF
--- a/spring-boot-starter-tomcat-proxies/src/main/java/org/zalando/stups/boot/tomcat/proxies/ConnectorCustomizer.java
+++ b/spring-boot-starter-tomcat-proxies/src/main/java/org/zalando/stups/boot/tomcat/proxies/ConnectorCustomizer.java
@@ -28,7 +28,7 @@ public class ConnectorCustomizer {
 
     private String scheme = "https";
 
-    private String proxyName = "localhost";
+    private String proxyName = "";
 
     private int proxyPort = 80;
 


### PR DESCRIPTION
Leave booties.tomcat.proxy.proxyName empty to return the hostname from the incoming call.
